### PR TITLE
Add glossary to manifest

### DIFF
--- a/static/fr640_3r-3v-example/html/index.html
+++ b/static/fr640_3r-3v-example/html/index.html
@@ -148,6 +148,7 @@
 				</tei-taxonomy>
 			</tei-classdecl>
 		</tei-encodingdesc>
+		<tei-link type="glossary" target="https://cu-mkp.github.io/editioncrafter-project/fr640_3r-3v-example/glossary.json" data-origname="link" data-empty=""></tei-link>
 	</tei-teiheader>
 	<tei-text xml:id="tl" id="tl" data-origname="text">
 		<tei-body data-origname="body">

--- a/static/fr640_3r-3v-example/iiif/manifest.json
+++ b/static/fr640_3r-3v-example/iiif/manifest.json
@@ -16807,5 +16807,13 @@
 		"en": [
 			"fr640_3r-3v-example"
 		]
-	}
+	},
+	"seeAlso": [
+		{
+			"id": "https://cu-mkp.github.io/editioncrafter-project/fr640_3r-3v-example/glossary.json",
+			"type": "Dataset",
+			"label": "Glossary",
+			"format": "text/json"
+		}
+	]
 }

--- a/static/fr640_3r-3v-example/tei/index.xml
+++ b/static/fr640_3r-3v-example/tei/index.xml
@@ -148,6 +148,7 @@
 				</taxonomy>
 			</classDecl>
 		</encodingDesc>
+		<link type="glossary" target="http://localhost:6006/fr640_3r-3v-example/glossary.json" />
 	</teiHeader>
 	<text xml:id="tl">
 		<body>


### PR DESCRIPTION
This PR adds a glossary link using the new `seeAlso` system.